### PR TITLE
feat(lib): qri.get_dataset function for updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           command: >
             go get -v -d -u
             github.com/jstemmer/go-junit-report 
+            github.com/qri-io/cafs
             github.com/qri-io/dataset
             github.com/google/skylark
             github.com/google/skylark/repl

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -122,8 +122,9 @@ func Marshal(data interface{}) (v skylark.Value, err error) {
     v = skylark.Bool(x)
   case string:
     v = skylark.String(x)
+  case int:
+    v = skylark.MakeInt(x)
   case float64:
-    // TODO - ints?
     v = skylark.Float(x)
   case []interface{}:
     var elems = make([]skylark.Value, len(x))

--- a/lib/qri/entry_writer.go
+++ b/lib/qri/entry_writer.go
@@ -1,0 +1,96 @@
+package qri
+
+import (
+	"fmt"
+
+	"github.com/google/skylark"
+	"github.com/qri-io/skytf/lib"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsio"
+	"github.com/qri-io/jsonschema"
+)
+
+// SkylarkEntryWriter creates a skylark.Value as an EntryWriter
+type SkylarkEntryWriter struct {
+	IsDict bool
+	Struct *dataset.Structure
+	Object skylark.Value
+}
+
+// WriteEntry adds an entry to the underlying skylark.Value
+func (w *SkylarkEntryWriter) WriteEntry(ent dsio.Entry) error {
+	if w.IsDict {
+		dict := w.Object.(*skylark.Dict)
+		key, err := lib.Marshal(ent.Key)
+		if err != nil {
+			return err
+		}
+		val, err := lib.Marshal(ent.Value)
+		if err != nil {
+			return err
+		}
+		dict.Set(key, val)
+	} else {
+		list := w.Object.(*skylark.List)
+		val, err := lib.Marshal(ent.Value)
+		if err != nil {
+			return err
+		}
+		list.Append(val)
+	}
+	return nil
+}
+
+// Structure returns the EntryWriter's dataset structure
+func (w *SkylarkEntryWriter) Structure() *dataset.Structure {
+	return w.Struct
+}
+
+// Close is a no-op
+func (w *SkylarkEntryWriter) Close() error {
+	return nil
+}
+
+// Value returns the underlying skylark.Value
+func (w *SkylarkEntryWriter) Value() skylark.Value {
+	return w.Object
+}
+
+// NewSkylarkEntryWriter returns a new SkylarkEntryWriter
+func NewSkylarkEntryWriter(st *dataset.Structure) (*SkylarkEntryWriter, error) {
+	mode, err := schemaScanMode(st.Schema)
+	if err != nil {
+		return nil, err
+	}
+	if mode == smObject {
+		return &SkylarkEntryWriter{IsDict: true, Struct: st, Object: &skylark.Dict{}}, nil
+	}
+	return &SkylarkEntryWriter{IsDict: false, Struct: st, Object: &skylark.List{}}, nil
+}
+
+// TODO: Refactor everything below this so that jsonschema returns this in a simple way
+type scanMode int
+
+const (
+	smArray scanMode = iota
+	smObject
+)
+
+// schemaScanMode determines weather the top level is an array or object
+func schemaScanMode(sc *jsonschema.RootSchema) (scanMode, error) {
+	if vt, ok := sc.Validators["type"]; ok {
+		// TODO - lol go PR jsonschema to export access to this instead of this
+		// silly validation hack
+		obj := []jsonschema.ValError{}
+		arr := []jsonschema.ValError{}
+		vt.Validate("", map[string]interface{}{}, &obj)
+		vt.Validate("", []interface{}{}, &arr)
+		if len(obj) == 0 {
+			return smObject, nil
+		} else if len(arr) == 0 {
+			return smArray, nil
+		}
+	}
+	err := fmt.Errorf("invalid schema. root must be either an array or object type")
+	return smArray, err
+}

--- a/lib/qri/qri_test.go
+++ b/lib/qri/qri_test.go
@@ -31,7 +31,7 @@ func TestNewModule(t *testing.T) {
 func newLoader(ds *dataset.Dataset) func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 	return func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 		if module == ModuleName {
-			return NewModule(ds, nil).Load()
+			return NewModule(ds, nil, nil).Load()
 		}
 
 		return nil, fmt.Errorf("invalid module")

--- a/transform.go
+++ b/transform.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/skylark"
 	"github.com/google/skylark/resolve"
+	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/skytf/lib"
@@ -34,7 +35,7 @@ func DefaultExecOpts(o *ExecOpts) {
 // ExecFile executes a transformation against a skylark file located at filepath, giving back an EntryReader of resulting data
 // ExecFile modifies the given dataset pointer. At bare minimum it will set transformation details, but skylark scripts can modify
 // many parts of the dataset pointer, including meta, structure, and transform
-func ExecFile(ds *dataset.Dataset, filename string, opts ...func(o *ExecOpts)) (dsio.EntryReader, error) {
+func ExecFile(ds *dataset.Dataset, filename string, infile cafs.File, opts ...func(o *ExecOpts)) (dsio.EntryReader, error) {
 	var (
 		scriptdata []byte
 		err        error
@@ -70,7 +71,7 @@ func ExecFile(ds *dataset.Dataset, filename string, opts ...func(o *ExecOpts)) (
 	ds.Transform.Script = bytes.NewReader(scriptdata)
 
 	// allocate skyqri module here so we can get data back post-execution
-	m := skyqri.NewModule(ds, o.Secrets)
+	m := skyqri.NewModule(ds, o.Secrets, infile)
 
 	thread := &skylark.Thread{Load: newLoader(ds, m)}
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestExecFile(t *testing.T) {
 	ds := &dataset.Dataset{}
-	er, err := ExecFile(ds, "testdata/tf.sky")
+	er, err := ExecFile(ds, "testdata/tf.sky", nil)
 	if err != nil {
 		t.Error(err.Error())
 		return
@@ -34,7 +34,7 @@ func TestExecFile(t *testing.T) {
 
 func TestExecFile2(t *testing.T) {
 	ds := &dataset.Dataset{}
-	_, err := ExecFile(ds, "testdata/fetch.sky")
+	_, err := ExecFile(ds, "testdata/fetch.sky", nil)
 	if err != nil {
 		t.Error(err.Error())
 		return


### PR DESCRIPTION
When a user calls ```qri update ....``` with a transformation, they can use qri.get_dataset() in skylark to get the body of the previous dataset.