### PR TITLE
feat(http): overhaul http module

### DIFF
--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -36,7 +36,7 @@ func (m *Module) Struct() *skylarkstruct.Struct {
 	return skylarkstruct.FromStringDict(skylarkstruct.Default, m.StringDict())
 }
 
-// StringDict returns all module methdos in a skylark.StringDict
+// StringDict returns all module methods in a skylark.StringDict
 func (m *Module) StringDict() skylark.StringDict {
 	return skylark.StringDict{
 		"get":     skylark.NewBuiltin("get", m.reqMethod("get")),

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -14,6 +14,7 @@ import (
 func TestNewModule(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Date", "Mon, 01 Jun 2000 00:00:00 GMT")
 		w.Write([]byte(`{"hello":"world"}`))
 	}))
 	skylark.Universe["test_server_url"] = skylark.String(ts.URL)
@@ -27,6 +28,7 @@ func TestNewModule(t *testing.T) {
 		},
 	}
 	thread := &skylark.Thread{Load: newLoader(ds)}
+	skylarktest.SetReporter(thread, t)
 
 	// Execute test file
 	_, err := skylark.ExecFile(thread, "testdata/test.sky", nil, nil)
@@ -40,7 +42,7 @@ func newLoader(ds *dataset.Dataset) func(thread *skylark.Thread, module string) 
 	return func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 		switch module {
 		case ModuleName:
-			return skylark.StringDict{"http" :NewModule(ds).Struct() }, nil
+			return skylark.StringDict{"http": NewModule(ds).Struct()}, nil
 		case "assert.sky":
 			return skylarktest.LoadAssertModule()
 		}

--- a/lib/http/testdata/test.sky
+++ b/lib/http/testdata/test.sky
@@ -1,8 +1,17 @@
 load('http.sky', 'http')
 load('assert.sky', 'assert')
 
-res_1 = http.get(test_server_url)
-assert.eq(res_1, '{"hello":"world"}')
+res_1 = http.get(test_server_url, params={ "a" : "b", "c" : "d"})
+assert.eq(res_1.url, test_server_url + "?a=b&c=d")
+assert.eq(res_1.status_code, 200)
+assert.eq(res_1.text(), '{"hello":"world"}')
+assert.eq(res_1.json(), {"hello":"world"})
 
-res_2 = http.get_json(test_server_url)
-assert.eq(res_2["hello"], "world")
+assert.eq(res_1.headers, {"Date": "Mon, 01 Jun 2000 00:00:00 GMT", "Content-Length": "17", "Content-Type": "text/plain; charset=utf-8"})
+
+res_2 = http.get(test_server_url)
+assert.eq(res_2.json()["hello"], "world")
+
+headers = {"foo" : "bar"}
+http.post(test_server_url, json={ "a" : "b", "c" : "d"}, headers=headers)
+http.post(test_server_url, data={ "a" : "b", "c" : "d"})

--- a/testdata/fetch.sky
+++ b/testdata/fetch.sky
@@ -1,7 +1,7 @@
 
 def download(qri):
-  res = qri.http.get_json('https://api.github.com/repos/qri-io/qri/releases')
-  return res[0]['assets']
+  res = qri.http.get(test_server_url)
+  return res.json()['foo']
 
 def transform(qri):
   return qri.download

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,8 +1,11 @@
 package skytf
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/google/skylark"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 )
@@ -33,8 +36,16 @@ func TestExecFile(t *testing.T) {
 }
 
 func TestExecFile2(t *testing.T) {
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"foo":["bar","baz","bat"]}`))
+	}))
+
 	ds := &dataset.Dataset{}
-	_, err := ExecFile(ds, "testdata/fetch.sky", nil)
+	_, err := ExecFile(ds, "testdata/fetch.sky", nil, func(o *ExecOpts) {
+		o.Globals["test_server_url"] = skylark.String(s.URL)
+	})
+
 	if err != nil {
 		t.Error(err.Error())
 		return


### PR DESCRIPTION
taking deep influence from the venerable Requests package in Python, I've overhauled the http module to provide a little more of the functionality one would come to expect from an http module. Lots more work to do here, but this covers a few basics, mainly working from [this docs page](http://docs.python-requests.org/en/master/user/quickstart/) of python's lovely Requests library.

Examples of transforms that should work:
```python
def download(qri):
  r = qri.http.get("https://api.github.com/qri-io/qri/releases")
  return r.json()[0]
```

```python
def download(qri):
  r = qri.http.post('http://httpbin.org/post', data = {'key':'value'})
  return r.text
```

```python
def download(qri):
  r = qri.http.post('http://httpbin.org/post', json = {'key':'value'})
  return r.text
```
