### PR TITLE
feat(html): add html module, set_schema method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             github.com/google/skylark/resolve
             github.com/qri-io/dataset
             github.com/qri-io/dataset/dsio
+            github.com/PuerkitoBio/goquery
       - run: 
           name: Run Lint Tests
           command: golint -set_exit_status ./... 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,55 @@
 [![CI](https://img.shields.io/circleci/project/github/qri-io/skytf.svg?style=flat-square)](https://circleci.com/gh/qri-io/skytf)
 [![Go Report Card](https://goreportcard.com/badge/github.com/qri-io/skytf)](https://goreportcard.com/report/github.com/qri-io/skytf)
 
-# skytf
+# Qri Skylark Transformation Syntax
 
-Skylark transformation syntax for qri datasets!
+Qri ("query") is about datasets. Transformions are repeatable scripts for generating a dataset. [Skylark](https://github.com/google/skylark/blob/master/doc/spec.md) is a scripting langauge from Google that feels a lot like python. This package implements skylark as a _transformation syntax_. Skylark tranformations are about as close as one can get to the full power of a programming language as a transformation syntax. Often you need this degree of control to generate a dataset.
+
+Typical examples of a skylark transformation include:
+* combining paginated calls to an API into a single dataset
+* downloading unstructured structured data from the internet to extract
+* re-shaping raw input data before saving a dataset
+
+We're excited about skylark for a few reasons:
+* **python syntax** - _many_ people working in data science these days write python, we like that, skylark likes that. dope.
+* **deterministic subset of python** - unlike python, skylark removes properties that reduce introspection into code behaviour. things like `while` loops and recursive functions are ommitted, making it possible for qri to infer how a given transformation will behave.
+* **parallel execution** - thanks to this deterministic requirement (and lack of global interpreter lock) skylark functions can be executed in parallel. Combined with peer-2-peer networking, we're hoping to advance tranformations toward peer-driven distribed computing. More on that in the coming months.
+
+
+## Getting started
+If you're mainly interested in learning how to write skylark transformations, our [documentation](https://qri.io/docs) is a better place to start. If you're interested in contributing to the way skylark transformations work, this is the place!
+
+The easiest way to see skylark transformations in action is to use [qri](https://github.com/qri-io/qri). This `skytf` package powers all the skylark stuff in qri. Assuming you have the [go programming language](https://golang.org/) the following should work from a terminal:
+```shell
+# get this package
+$ go get github.com/qri-io/skytf
+
+# navigate to package
+$ cd $GOPATH/src/github.com/qri-io/skytf
+
+# run tests
+$ go test ./...
+```
+
+Often the next steps are to install [qri](https://github.com/qri-io/qri), mess with this `skytf` package, then rebuild qri with your changes to see them in action within qri itself.
+
+## Skylark Data Functions
+
+Data Functions are the core of a skylark transform script. Here's an example of a _very_ simple data function:
+
+```python
+def transform(qri):
+  return(["hello","world"])
+```
+ 
+Skylark transformations have a few rules on top of skylark itself:
+* Data functions *always* return data
+* When you define a data function, qri calls it for you
+* All tranform functions are optional (you don't _need_ to define them), _but_
+* A transformation must have at least one data function
+* Data functions are always called in the same order
+* Data functions often get a `qri` parameter that lets them do special things
+
+
+
+** **

--- a/lib/html/html.go
+++ b/lib/html/html.go
@@ -1,0 +1,183 @@
+package html
+
+import (
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/google/skylark"
+	"github.com/google/skylark/skylarkstruct"
+	"github.com/qri-io/skytf/lib"
+)
+
+// ModuleName defines the expected name for this Module when used
+// in skylark's load() function, eg: load('html.sky', 'html')
+const ModuleName = "html.sky"
+
+// NewDocument creates a skylark selection from input text
+func NewDocument(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var body skylark.String
+	if err := skylark.UnpackArgs("html", args, kwargs, "body", &body); err != nil {
+		return nil, err
+	}
+
+	str, err := lib.AsString(body)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(str))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSelectionStruct(doc.Selection), err
+}
+
+// Selection is a wrapper for a goquery selection mapping to skylark values
+type Selection struct {
+	sel *goquery.Selection
+}
+
+// NewSelectionStruct creates a skylark struct from a goquery selection
+func NewSelectionStruct(s *goquery.Selection) *skylarkstruct.Struct {
+	sel := &Selection{sel: s}
+	return sel.Struct()
+}
+
+// Struct returns a skylark struct of methods
+func (s *Selection) Struct() *skylarkstruct.Struct {
+	return skylarkstruct.FromStringDict(skylarkstruct.Default, skylark.StringDict{
+		"attr":              skylark.NewBuiltin("attr", s.Attr),
+		"children":          skylark.NewBuiltin("children", s.Children),
+		"children_filtered": skylark.NewBuiltin("children_filtered", s.ChildrenFiltered),
+		"contents":          skylark.NewBuiltin("contents", s.Contents),
+		"find":              skylark.NewBuiltin("find", s.Find),
+		"filter":            skylark.NewBuiltin("filter", s.Filter),
+		"get":               skylark.NewBuiltin("get", s.Get),
+		"has":               skylark.NewBuiltin("has", s.Has),
+		"parent":            skylark.NewBuiltin("parent", s.Parent),
+		"parents_until":     skylark.NewBuiltin("parents_until", s.ParentsUntil),
+		"siblings":          skylark.NewBuiltin("siblings", s.Siblings),
+		"text":              skylark.NewBuiltin("text", s.Text),
+	})
+}
+
+// Attr gets the specified attribute's value for the first element in the Selection. To get the value for each element individually, use a looping construct such as Each or Map method
+func (s *Selection) Attr(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("attr", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	val, exists := s.sel.Attr(sstr)
+	if !exists {
+		return skylark.None, nil
+	}
+	return skylark.String(val), nil
+}
+
+// Children gets the child elements of each element in the Selection. It returns a new Selection object containing these elements
+func (s *Selection) Children(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return NewSelectionStruct(s.sel.Children()), nil
+}
+
+// ChildrenFiltered gets the child elements of each element in the Selection, filtered by the specified selector. It returns a new Selection object containing these elements
+func (s *Selection) ChildrenFiltered(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("children_filtered", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	sel := s.sel.ChildrenFiltered(sstr)
+	return NewSelectionStruct(sel), nil
+}
+
+// Contents gets the children of each element in the Selection, including text and comment nodes. It returns a new Selection object containing these elements
+func (s *Selection) Contents(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return NewSelectionStruct(s.sel.Contents()), nil
+}
+
+// func (s *Selection) Each(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+// }
+
+// Get retrieves the underlying node at the specified index. Get without parameter is not implemented, since the node array is available on the Selection object
+func (s *Selection) Get(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Int
+	if err := skylark.UnpackPositionalArgs("get", args, kwargs, 1, &x); err != nil {
+		var t skylark.Tuple
+		for _, node := range s.sel.Nodes {
+			t = append(t, skylark.String(node.Data))
+		}
+		return t, nil
+	}
+
+	i, _ := x.Int64()
+	if int(i) > len(s.sel.Nodes)-1 {
+		return skylark.None, nil
+	}
+	sel := s.sel.Get(int(i))
+	return skylark.String(sel.Data), nil
+}
+
+// Find gets the descendants of each element in the current set of matched elements, filtered by a selector. It returns a new Selection object containing these matched element
+func (s *Selection) Find(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("find", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	sel := s.sel.Find(sstr)
+	return NewSelectionStruct(sel), nil
+}
+
+// Filter reduces the set of matched elements to those that match the selector string. It returns a new Selection object for this subset of matching elements
+func (s *Selection) Filter(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("filter", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	sel := s.sel.Filter(sstr)
+	return NewSelectionStruct(sel), nil
+}
+
+// Has reduces the set of matched elements to those that have a descendant that matches the selector. It returns a new Selection object with the matching elements
+func (s *Selection) Has(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("has", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	sel := s.sel.Has(sstr)
+	return NewSelectionStruct(sel), nil
+}
+
+// Parent gets the parent of each element in the Selection. It returns a new Selection object containing the matched elements
+func (s *Selection) Parent(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return NewSelectionStruct(s.sel.Parent()), nil
+}
+
+// ParentsUntil gets the ancestors of each element in the Selection, up to but not including the element matched by the selector. It returns a new Selection object containing the matched elements
+func (s *Selection) ParentsUntil(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sstr, err := s.selectorArg("parents_until", args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	sel := s.sel.ParentsUntil(sstr)
+	return NewSelectionStruct(sel), nil
+}
+
+// selectorArg is a convenience method for functions that only accept a string selector
+func (s *Selection) selectorArg(method string, args skylark.Tuple, kwargs []skylark.Tuple) (string, error) {
+	var selector skylark.String
+	if err := skylark.UnpackPositionalArgs(method, args, kwargs, 1, &selector); err != nil {
+		return "", err
+	}
+	return lib.AsString(selector)
+}
+
+// Siblings gets the siblings of each element in the Selection. It returns a new Selection object containing the matched elements
+func (s *Selection) Siblings(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	sel := s.sel.Siblings()
+	return NewSelectionStruct(sel), nil
+}
+
+// Text gets the combined text contents of each element in the set of matched elements, including their descendants
+func (s *Selection) Text(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return skylark.String(s.sel.Text()), nil
+}

--- a/lib/html/html_test.go
+++ b/lib/html/html_test.go
@@ -1,0 +1,34 @@
+package html
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/skylark"
+	"github.com/google/skylark/skylarktest"
+)
+
+func TestModule(t *testing.T) {
+	thread := &skylark.Thread{Load: newLoader()}
+	skylarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := skylark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
+	return func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
+		switch module {
+		case ModuleName:
+			return skylark.StringDict{"html": skylark.NewBuiltin("html", NewDocument)}, nil
+		case "assert.sky":
+			return skylarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
+}

--- a/lib/html/testdata/test.sky
+++ b/lib/html/testdata/test.sky
@@ -1,0 +1,43 @@
+load('html.sky', 'html')
+load('assert.sky', 'assert')
+
+htmlstr = """
+<!DOCTYPE html>
+<html>
+<head>
+  <title>example page</title>
+</head>
+<body id="A" class="le_body">
+  <header id="B">Header Tag</header>
+  <section id="C">
+    <div id="D" class="le_div">
+      <h1 id="E" data-name="foo">Heading One</h1>
+      <p id="F" class="paragraph">Paragraph</p>
+    </div>
+  </section>
+  <footer id="G">
+    <a id="H" href="http://foo.com">link</a>
+  </footer>
+</body>
+</html>
+"""
+
+doc = html(htmlstr)
+
+assert.eq(doc.children().text(), "\n  example page\n\n\n  Header Tag\n  \n    \n      Heading One\n      Paragraph\n    \n  \n  \n    link\n  \n\n\n")
+assert.eq(doc.find("#E").text(), "Heading One")
+assert.eq(doc.find("body header").text(), "Header Tag")
+assert.eq(doc.find("#F").text(), "Paragraph")
+assert.eq(doc.find("#E").attr("data-name"), "foo")
+assert.eq(doc.contents().text(), "\n  example page\n\n\n  Header Tag\n  \n    \n      Heading One\n      Paragraph\n    \n  \n  \n    link\n  \n\n\n")
+assert.eq(doc.find("footer").children().attr("href"), "http://foo.com")
+assert.eq(doc.find("#D").children_filtered("#E").attr("data-name"), "foo")
+assert.eq(doc.find("#D").children().filter("h1").attr("data-name"), "foo")
+assert.eq(doc.has("#B").find("header").text(), "Header Tag")
+
+p = doc.find("p")
+assert.eq(p.parent().attr("class"), "le_div")
+assert.eq(p.parents_until("body").attr("class"), "le_div")
+assert.eq(p.siblings().text(), "Heading One")
+assert.eq(p.get(), ("p",))
+assert.eq(p.get(0), "p")

--- a/lib/qri/entry_writer.go
+++ b/lib/qri/entry_writer.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/google/skylark"
-	"github.com/qri-io/skytf/lib"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/jsonschema"
+	"github.com/qri-io/skytf/lib"
 )
 
 // SkylarkEntryWriter creates a skylark.Value as an EntryWriter

--- a/lib/qri/testdata/test.sky
+++ b/lib/qri/testdata/test.sky
@@ -1,3 +1,5 @@
 load('qri.sky', 'qri')
 
 foo = qri.get_config("foo")
+
+qri.set_schema({ "type" : "object" })

--- a/skytf.go
+++ b/skytf.go
@@ -2,4 +2,4 @@ package skytf
 
 // Version is the current version of this skytf, this version number will be written
 // with each transformation exectution
-const Version = "0.0.1"
+const Version = "0.0.2-dev"

--- a/transform.go
+++ b/transform.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qri-io/dataset/dsio"
 	"github.com/qri-io/skytf/lib"
 
+	skyhtml "github.com/qri-io/skytf/lib/html"
 	skyhttp "github.com/qri-io/skytf/lib/http"
 	skyqri "github.com/qri-io/skytf/lib/qri"
 )
@@ -189,6 +190,7 @@ func (t *transform) callDownloadFunc(thread *skylark.Thread, prev skylark.Iterab
 		"get_config": skylark.NewBuiltin("get_config", qm.GetConfig),
 		"get_secret": skylark.NewBuiltin("get_secret", qm.GetSecret),
 		"http":       skyhttp.NewModule(t.ds).Struct(),
+		"html":       skylark.NewBuiltin("html", skyhtml.NewDocument),
 	})
 
 	x, err := download.Call(thread, skylark.Tuple{qri}, nil)
@@ -210,6 +212,7 @@ func (t *transform) callTransformFunc(thread *skylark.Thread, prev skylark.Itera
 	qm := skyqri.NewModule(t.ds, t.secrets, t.infile)
 	qri := skylarkstruct.FromStringDict(skylarkstruct.Default, qm.AddAllMethods(skylark.StringDict{
 		"download": t.download,
+		"html":     skylark.NewBuiltin("html", skyhtml.NewDocument),
 	}))
 
 	x, err := transform.Call(thread, skylark.Tuple{qri}, nil)


### PR DESCRIPTION
so, uh, this isn't exactly the best, but I'd really like to at least have a stand-in implementation for working with html documents in a sane way. I've never used beautifulsoup, and I'm guessing this'll aanger many pythonists, but to me jquery-style syntax / css selectors are the single best way to slice & dice html tags, so it's a start.