### PR TITLE
feat(NtwkToggle): explicit network use toggling in http package

### DIFF
--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -19,6 +19,23 @@ import (
 // in skylark's load() function, eg: load('http.sky', 'http')
 const ModuleName = "http.sky"
 
+var (
+	// ntwkEnabled controls use of this entire module with enable/disable methods
+	ntwkEnabled = true
+	// ErrNtwkDisabled is returned whenever a network call is attempted but ntwkEnabled is false
+	ErrNtwkDisabled = fmt.Errorf("network use is disabled")
+)
+
+// EnableNtwk allows network calls
+func EnableNtwk() {
+	ntwkEnabled = true
+}
+
+// DisableNtwk prevents network calls from succeeding
+func DisableNtwk() {
+	ntwkEnabled = false
+}
+
 // NewModule creates an http Module
 func NewModule(ds *dataset.Dataset) *Module {
 	return &Module{ds: ds, cli: http.DefaultClient}
@@ -51,6 +68,10 @@ func (m *Module) StringDict() skylark.StringDict {
 // reqMethod is a factory function for generating skylark builtin functions for different http request methods
 func (m *Module) reqMethod(method string) func(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	return func(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+		if !ntwkEnabled {
+			return nil, ErrNtwkDisabled
+		}
+
 		var (
 			urlv     skylark.String
 			params   = &skylark.Dict{}

--- a/skytf.go
+++ b/skytf.go
@@ -2,4 +2,4 @@ package skytf
 
 // Version is the current version of this skytf, this version number will be written
 // with each transformation exectution
-const Version = "0.0.2-dev"
+const Version = "0.0.2"

--- a/transform.go
+++ b/transform.go
@@ -106,10 +106,12 @@ func ExecFile(ds *dataset.Dataset, filename string, infile cafs.File, opts ...fu
 	}
 
 	var data skylark.Iterable
+	skyhttp.EnableNtwk()
 	data, err = t.callDownloadFunc(thread, data)
 	if err != nil {
 		return nil, err
 	}
+	skyhttp.DisableNtwk()
 	t.download = data
 
 	data, err = t.callTransformFunc(thread, data)


### PR DESCRIPTION
this is a quick security check to prevent the following theoretical code:

```python
bad_qri = None

def download(qri):
  bad_qri = qri

def transform(qri):
  bad_qri.http.post("...")
  return ["up","in","yer","qri","data"]
```

This adds an explicit lock that only allows the http module to be accessed when calling the transform step.