### PR TITLE
feat(html): add `first`, `last`, `eq`, `len` functions

### DIFF
--- a/lib/html/html.go
+++ b/lib/html/html.go
@@ -59,6 +59,10 @@ func (s *Selection) Struct() *skylarkstruct.Struct {
 		"parents_until":     skylark.NewBuiltin("parents_until", s.ParentsUntil),
 		"siblings":          skylark.NewBuiltin("siblings", s.Siblings),
 		"text":              skylark.NewBuiltin("text", s.Text),
+		"first":             skylark.NewBuiltin("first", s.First),
+		"last":              skylark.NewBuiltin("last", s.Last),
+		"len":               skylark.NewBuiltin("len", s.Len),
+		"eq":                skylark.NewBuiltin("eq", s.Eq),
 	})
 }
 
@@ -95,6 +99,7 @@ func (s *Selection) Contents(thread *skylark.Thread, _ *skylark.Builtin, args sk
 	return NewSelectionStruct(s.sel.Contents()), nil
 }
 
+// // Each
 // func (s *Selection) Each(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 // }
 
@@ -180,4 +185,30 @@ func (s *Selection) Siblings(thread *skylark.Thread, _ *skylark.Builtin, args sk
 // Text gets the combined text contents of each element in the set of matched elements, including their descendants
 func (s *Selection) Text(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	return skylark.String(s.sel.Text()), nil
+}
+
+// First gets the first element of the selection
+func (s *Selection) First(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return NewSelectionStruct(s.sel.First()), nil
+}
+
+// Last gets the last element of the selection
+func (s *Selection) Last(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return NewSelectionStruct(s.sel.Last()), nil
+}
+
+// Eq gets the element i of the selection
+func (s *Selection) Eq(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Int
+	if err := skylark.UnpackPositionalArgs("eq", args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+
+	i, _ := x.Int64()
+	return NewSelectionStruct(s.sel.Eq(int(i))), nil
+}
+
+// Len returns the length of the nodes in the selection
+func (s *Selection) Len(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	return skylark.MakeInt(len(s.sel.Nodes)), nil
 }

--- a/lib/html/testdata/test.sky
+++ b/lib/html/testdata/test.sky
@@ -34,6 +34,11 @@ assert.eq(doc.find("footer").children().attr("href"), "http://foo.com")
 assert.eq(doc.find("#D").children_filtered("#E").attr("data-name"), "foo")
 assert.eq(doc.find("#D").children().filter("h1").attr("data-name"), "foo")
 assert.eq(doc.has("#B").find("header").text(), "Header Tag")
+assert.eq(doc.find("#A").children().first().text(), "Header Tag")
+assert.eq(doc.find("#A").children().last().text(), "\n    link\n  ")
+assert.eq(doc.find("#A").children().eq(0).text(), "Header Tag")
+assert.eq(doc.find("#A").children().len(), 3)
+
 
 p = doc.find("p")
 assert.eq(p.parent().attr("class"), "le_div")
@@ -41,3 +46,4 @@ assert.eq(p.parents_until("body").attr("class"), "le_div")
 assert.eq(p.siblings().text(), "Heading One")
 assert.eq(p.get(), ("p",))
 assert.eq(p.get(0), "p")
+


### PR DESCRIPTION
While writing a transformation that would parse html doc into a dataset, I ran into some road blocks.

It seems like we have to have further discussion about exactly what format our html parsing library takes, (#7) but for now I've added skylark functions for:
* first(), returns the first node in the Selection as a new Selection
* last(), return the last node in the Selection as a new Selection
* eq(int) (this is just called eq because that is what the underlying goquery calls it, open to renaming, but maybe should be called index. It returns a Selection from the node at the given index)
* len(), returns the number of nodes in the Selection