### PR TITLE
feat(raw body): add raw flag to ds.set_body

### DIFF
--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -152,13 +152,12 @@ func (d *Dataset) SetBody(thread *skylark.Thread, _ *skylark.Builtin, args skyla
 	}
 
 	if raw {
-		fmt.Println("raw data y'all")
 		if str, ok := data.(skylark.String); ok {
 			d.infile = cafs.NewMemfileBytes("data", []byte(string(str)))
-		} else {
-			return skylark.None, fmt.Errorf("expected raw data for body to be a string")
+			return skylark.None, nil
 		}
-		return skylark.None, nil
+
+		return skylark.None, fmt.Errorf("expected raw data for body to be a string")
 	}
 
 	iter, ok := data.(skylark.Iterable)

--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -142,9 +142,28 @@ func (d *Dataset) GetBody(thread *skylark.Thread, _ *skylark.Builtin, args skyla
 
 // SetBody assigns the dataset body
 func (d *Dataset) SetBody(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
-	var data skylark.Iterable
-	if err := skylark.UnpackPositionalArgs("set_body", args, kwargs, 1, &data); err != nil {
+	var (
+		data skylark.Value
+		raw  skylark.Bool
+	)
+
+	if err := skylark.UnpackArgs("set_body", args, kwargs, "data", &data, "raw?", &raw); err != nil {
 		return skylark.None, err
+	}
+
+	if raw {
+		fmt.Println("raw data y'all")
+		if str, ok := data.(skylark.String); ok {
+			d.infile = cafs.NewMemfileBytes("data", []byte(string(str)))
+		} else {
+			return skylark.None, fmt.Errorf("expected raw data for body to be a string")
+		}
+		return skylark.None, nil
+	}
+
+	iter, ok := data.(skylark.Iterable)
+	if !ok {
+		return skylark.None, fmt.Errorf("expected body to be iterable")
 	}
 
 	sch := dataset.BaseSchemaArray
@@ -162,10 +181,10 @@ func (d *Dataset) SetBody(thread *skylark.Thread, _ *skylark.Builtin, args skyla
 	}
 	w, err := dsio.NewEntryBuffer(st)
 	if err != nil {
-		return nil, err
+		return skylark.None, err
 	}
 
-	r := NewEntryReader(st, data)
+	r := NewEntryReader(st, iter)
 	if err := dsio.Copy(r, w); err != nil {
 		return skylark.None, err
 	}

--- a/skytf.go
+++ b/skytf.go
@@ -2,4 +2,4 @@ package skytf
 
 // Version is the current version of this skytf, this version number will be written
 // with each transformation exectution
-const Version = "0.0.4-dev"
+const Version = "0.0.4"

--- a/transform_test.go
+++ b/transform_test.go
@@ -12,13 +12,19 @@ import (
 
 func TestExecFile(t *testing.T) {
 	ds := &dataset.Dataset{}
-	er, err := ExecFile(ds, "testdata/tf.sky", nil)
+	body, err := ExecFile(ds, "testdata/tf.sky", nil)
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
 	if ds.Transform == nil {
 		t.Error("expected transform")
+	}
+
+	er, err := dsio.NewEntryReader(ds.Structure, body)
+	if err != nil {
+		t.Errorf("couldn't create entry reader from returned dataset & body file: %s", err.Error())
+		return
 	}
 
 	i := 0

--- a/transform_test.go
+++ b/transform_test.go
@@ -21,14 +21,14 @@ func TestExecFile(t *testing.T) {
 		t.Error("expected transform")
 	}
 
-	er, err := dsio.NewEntryReader(ds.Structure, body)
+	entryReader, err := dsio.NewEntryReader(ds.Structure, body)
 	if err != nil {
 		t.Errorf("couldn't create entry reader from returned dataset & body file: %s", err.Error())
 		return
 	}
 
 	i := 0
-	dsio.EachEntry(er, func(_ int, x dsio.Entry, e error) error {
+	dsio.EachEntry(entryReader, func(_ int, x dsio.Entry, e error) error {
 		if e != nil {
 			t.Errorf("entry %d iteration error: %s", i, e.Error())
 		}


### PR DESCRIPTION
also refactored return of `ExecTransform` to return a cafs.File instead of a `dsio.EntryReader`. `dsio.EntryReader` is one abstraction too high if we're going to return raw data.

This PR also ups the version number of skytf to 0.0.4, dropping the `-dev` label.