### PR TITLE
chore(release): version bump to v0.1.0

### DIFF
--- a/skytf.go
+++ b/skytf.go
@@ -2,4 +2,4 @@ package skytf
 
 // Version is the current version of this skytf, this version number will be written
 // with each transformation exectution
-const Version = "0.0.4"
+const Version = "0.1.0"


### PR DESCRIPTION
this version bump is entirely to signify changes to the underlying starlib library, which adds the new re & zip packages. I think we should move to 0.1.0 now that skytf is no longer an experiment