### PR TITLE
feat(context): revise transform steps to match rfc, add transform context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
-      - run: go get github.com/jstemmer/go-junit-report github.com/golang/lint/golint
+      - run: go get github.com/jstemmer/go-junit-report golang.org/x/lint/golint
       - run:
           name: Install non-gx deps
           command: >

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,29 @@
+package context
+
+import (
+	"context"
+
+	"github.com/google/skylark"
+	"github.com/google/skylark/skylarkstruct"
+)
+
+// Context carries values across function calls in a transformation
+type Context struct {
+	// Results carries the return values of special function calls
+	Results skylark.StringDict
+}
+
+// NewContext creates a new contex
+func NewContext() *Context {
+	context.Background()
+	return &Context{
+		Results: skylark.StringDict{},
+	}
+}
+
+// Struct delivers this context as a skylark struct
+func (c *Context) Struct() *skylarkstruct.Struct {
+	return skylarkstruct.FromStringDict(skylark.String("context"), skylark.StringDict{
+		"results": skylarkstruct.FromStringDict(skylark.String("results"), c.Results),
+	})
+}

--- a/context/context.go
+++ b/context/context.go
@@ -1,29 +1,67 @@
 package context
 
 import (
-	"context"
+	"fmt"
 
-	"github.com/google/skylark"
+	starlark "github.com/google/skylark"
 	"github.com/google/skylark/skylarkstruct"
 )
 
 // Context carries values across function calls in a transformation
 type Context struct {
 	// Results carries the return values of special function calls
-	Results skylark.StringDict
+	results starlark.StringDict
+	values  starlark.StringDict
 }
 
 // NewContext creates a new contex
 func NewContext() *Context {
-	context.Background()
 	return &Context{
-		Results: skylark.StringDict{},
+		results: starlark.StringDict{},
+		values:  starlark.StringDict{},
 	}
 }
 
 // Struct delivers this context as a skylark struct
 func (c *Context) Struct() *skylarkstruct.Struct {
-	return skylarkstruct.FromStringDict(skylark.String("context"), skylark.StringDict{
-		"results": skylarkstruct.FromStringDict(skylark.String("results"), c.Results),
-	})
+	dict := starlark.StringDict{
+		"set": starlark.NewBuiltin("set", c.setValue),
+		"get": starlark.NewBuiltin("get", c.getValue),
+	}
+
+	for k, v := range c.results {
+		dict[k] = v
+	}
+
+	return skylarkstruct.FromStringDict(starlark.String("context"), dict)
+}
+
+// SetResult places the result of a function call in the results stringDict
+// any results set here will be placed in the context struct field by name
+func (c *Context) SetResult(name string, value starlark.Value) {
+	c.results[name] = value
+}
+
+func (c *Context) setValue(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		key   starlark.String
+		value starlark.Value
+	)
+	if err := starlark.UnpackArgs("set", args, kwargs, "key", &key, "value", &value); err != nil {
+		return starlark.None, err
+	}
+
+	c.values[string(key)] = value
+	return starlark.None, nil
+}
+
+func (c *Context) getValue(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var key starlark.String
+	if err := starlark.UnpackArgs("get", args, kwargs, "key", &key); err != nil {
+		return starlark.None, err
+	}
+	if v, ok := c.values[string(key)]; ok {
+		return v, nil
+	}
+	return starlark.None, fmt.Errorf("value %s not set in context", string(key))
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,0 +1,51 @@
+package context
+
+import (
+	"fmt"
+	"testing"
+
+	starlark "github.com/google/skylark"
+	starlarktest "github.com/google/skylark/skylarktest"
+)
+
+func TestContext(t *testing.T) {
+	thread := &starlark.Thread{Load: newLoader()}
+
+	dlCtx := NewContext()
+	dlCtx.SetResult("download", starlark.Bool(true))
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, starlark.StringDict{
+		"ctx":    NewContext().Struct(),
+		"dl_ctx": dlCtx.Struct(),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMissingValue(t *testing.T) {
+	thread := &starlark.Thread{Load: newLoader()}
+
+	ctx := NewContext()
+	val, err := ctx.getValue(thread, nil, starlark.Tuple{starlark.String("foo")}, nil)
+	if val != starlark.None {
+		t.Errorf("expected none return value")
+	}
+
+	if err.Error() != "value foo not set in context" {
+		t.Errorf("error message mismatch. expected: %s, got: %s", "value foo not set in context", err.Error())
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	return func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		switch module {
+		case "assert.sky":
+			return starlarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
+}

--- a/context/testdata/test.sky
+++ b/context/testdata/test.sky
@@ -1,0 +1,6 @@
+# predeclared globals for test: ctx, dl_ctx 
+load("assert.sky", "assert")
+
+ctx.set("foo", "bar")
+assert.eq(ctx.get("foo"), "bar")
+assert.eq(dl_ctx.download, True)

--- a/ds/dataset.go
+++ b/ds/dataset.go
@@ -58,10 +58,7 @@ func (d *Dataset) SetMeta(thread *skylark.Thread, _ *skylark.Builtin, args skyla
 		return nil, fmt.Errorf("expected key to be a string")
 	}
 
-	key, err := util.AsString(keyx)
-	if err != nil {
-		return nil, fmt.Errorf("parsing string key: %s", err.Error())
-	}
+	key := string(keyx.(skylark.String))
 
 	val, err := util.Unmarshal(valx)
 	if err != nil {

--- a/qri/qri.go
+++ b/qri/qri.go
@@ -168,21 +168,12 @@ func (m *Module) GetSecret(thread *skylark.Thread, _ *skylark.Builtin, args skyl
 		return skylark.None, nil
 	}
 
-	var keyx skylark.Value
-	if err := skylark.UnpackPositionalArgs("get_secret", args, kwargs, 1, &keyx); err != nil {
+	var key skylark.String
+	if err := skylark.UnpackPositionalArgs("get_secret", args, kwargs, 1, &key); err != nil {
 		return nil, err
 	}
 
-	if keyx.Type() != "string" {
-		return nil, fmt.Errorf("expected key to be a string")
-	}
-
-	key, err := util.AsString(keyx)
-	if err != nil {
-		return nil, fmt.Errorf("parsing string key: %s", err.Error())
-	}
-
-	return util.Marshal(m.secrets[key])
+	return util.Marshal(m.secrets[string(key)])
 }
 
 // GetConfig returns transformation configuration details
@@ -192,19 +183,10 @@ func (m *Module) GetConfig(thread *skylark.Thread, _ *skylark.Builtin, args skyl
 		return skylark.None, nil
 	}
 
-	var keyx skylark.Value
-	if err := skylark.UnpackPositionalArgs("get_config", args, kwargs, 1, &keyx); err != nil {
+	var key skylark.String
+	if err := skylark.UnpackPositionalArgs("get_config", args, kwargs, 1, &key); err != nil {
 		return nil, err
 	}
 
-	if keyx.Type() != "string" {
-		return nil, fmt.Errorf("expected key to be a string")
-	}
-
-	key, err := util.AsString(keyx)
-	if err != nil {
-		return nil, fmt.Errorf("parsing string key: %s", err.Error())
-	}
-
-	return util.Marshal(m.ds.Transform.Config[key])
+	return util.Marshal(m.ds.Transform.Config[string(key)])
 }

--- a/skytf.go
+++ b/skytf.go
@@ -2,4 +2,4 @@ package skytf
 
 // Version is the current version of this skytf, this version number will be written
 // with each transformation exectution
-const Version = "0.1.0"
+const Version = "0.1.0-dev"

--- a/testdata/fetch.sky
+++ b/testdata/fetch.sky
@@ -6,4 +6,4 @@ def download(ctx):
   return res.json()['foo']
 
 def transform(ds, ctx):
-  ds.set_body(ctx.results.download)
+  ds.set_body(ctx.download)

--- a/testdata/fetch.sky
+++ b/testdata/fetch.sky
@@ -1,6 +1,9 @@
 load("http.sky", "http")
+load("qri.sky", "qri")
 
-def download(ds):
+def download(ctx):
   res = http.get(test_server_url)
-  ds.set_body(res.json()['foo'])
-  return ds
+  return res.json()['foo']
+
+def transform(ds, ctx):
+  ds.set_body(ctx.results.download)

--- a/testdata/tf.sky
+++ b/testdata/tf.sky
@@ -1,4 +1,4 @@
 
-def transform(ds):
+def transform(ds, ctx):
   ds.set_body([1, 1.5, False, 'a','b','c', { "a" : 1, "b" : True }, [1,2]])
   return ds

--- a/transform.go
+++ b/transform.go
@@ -15,7 +15,6 @@ import (
 	skyds "github.com/qri-io/skytf/ds"
 	skyqri "github.com/qri-io/skytf/qri"
 	"github.com/qri-io/starlib"
-	"github.com/qri-io/starlib/util"
 )
 
 // ExecOpts defines options for execution
@@ -152,10 +151,8 @@ func Error(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwarg
 	if err := skylark.UnpackPositionalArgs("error", args, kwargs, 1, &msg); err != nil {
 		return nil, err
 	}
-	if str, err := util.AsString(msg); err == nil {
-		return nil, fmt.Errorf("transform error: %s", str)
-	}
-	return nil, fmt.Errorf("tranform errored (no valid message provided)")
+
+	return nil, fmt.Errorf("transform error: %s", msg)
 }
 
 // ErrNotDefined is for when a skylark value is not defined or does not exist

--- a/transform.go
+++ b/transform.go
@@ -148,7 +148,7 @@ func ExecFile(ds *dataset.Dataset, filename string, bodyFile cafs.File, opts ...
 			return nil, err
 		}
 
-		ctx.Results[name] = val
+		ctx.SetResult(name, val)
 	}
 
 	err = callTransformFunc(t, thread, ctx)


### PR DESCRIPTION
This brings our skylark implementation in line with the changes described in [rfc no.16](qri-io/rfcs#24).

Lotsa breaking changes. I'm hoping to follow this rather quickly with a starlark rename so we can make all the breaking changes at once.